### PR TITLE
Make client API more seamless

### DIFF
--- a/examples/client/Feed.tsx
+++ b/examples/client/Feed.tsx
@@ -6,7 +6,7 @@ import * as Nars from "nars-client";
 
 import { green } from "./Colors";
 
-const RemoteComponent = Nars.createRemoteComponentWithUrl(
+const { Feed } = Nars.createRemoteComponentWithUrl(
   "ws://localhost:9000",
   config
 );
@@ -14,10 +14,7 @@ const RemoteComponent = Nars.createRemoteComponentWithUrl(
 const Component = ({ animationProgress }) => {
   return (
     <Animated.View style={[{ opacity: animationProgress }, styles.container]}>
-      <RemoteComponent
-        name="Feed"
-        props={{ backgroundColor: "yellow" }}
-      />
+      <Feed backgroundColor={"yellow"} />
     </Animated.View>
   );
 };

--- a/examples/client/Form.tsx
+++ b/examples/client/Form.tsx
@@ -12,7 +12,7 @@ const styles = StyleSheet.create({
   },
 });
 
-const RemoteComponent = Nars.createRemoteComponentWithUrl(
+const { Form } = Nars.createRemoteComponentWithUrl(
   "ws://localhost:9000",
   config
 );
@@ -20,12 +20,7 @@ const RemoteComponent = Nars.createRemoteComponentWithUrl(
 const Component = ({ animationProgress }) => {
   return (
     <Animated.View style={[{ opacity: animationProgress }, styles.container]}>
-      <RemoteComponent
-        name="Form"
-        props={{
-          isCompany: true,
-        }}
-      />
+      <Form isCompany={true} />
     </Animated.View>
   );
 };

--- a/examples/client/ProgressBar.tsx
+++ b/examples/client/ProgressBar.tsx
@@ -6,7 +6,7 @@ import * as Nars from "nars-client";
 
 import { lightGreen } from "./Colors";
 
-const RemoteComponent = Nars.createRemoteComponentWithUrl(
+const { ProgressBar } = Nars.createRemoteComponentWithUrl(
   "ws://localhost:9000",
   config
 );
@@ -14,10 +14,7 @@ const RemoteComponent = Nars.createRemoteComponentWithUrl(
 const Component = ({ animationProgress }) => {
   return (
     <Animated.View style={[{ opacity: animationProgress }, styles.container]}>
-      <RemoteComponent
-        name="ProgressBar"
-        props={{ height: 30 }}
-      />
+      <ProgressBar height={30} />
     </Animated.View>
   );
 };

--- a/examples/client/package.json
+++ b/examples/client/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "faker": "^4.1.0",
-    "nars-client": "1.0.0-alpha.6",
+    "nars-client": "1.0.0-alpha.7",
     "nars-common": "1.0.0-alpha.3",
     "nars-examples-common": "*",
     "react": "16.9.0",

--- a/packages/integration_tests/package.json
+++ b/packages/integration_tests/package.json
@@ -8,7 +8,7 @@
   "private": true,
   "dependencies": {
     "nars": "1.0.0-alpha.10",
-    "nars-client": "1.0.0-alpha.6"
+    "nars-client": "1.0.0-alpha.7"
   },
   "devDependencies": {
     "@types/jest": "^24.0.18",

--- a/packages/integration_tests/src/CallbackProp.test.tsx
+++ b/packages/integration_tests/src/CallbackProp.test.tsx
@@ -88,10 +88,14 @@ const components = {
   },
 };
 
-const [RemoteComponent, createServer] = createRemoteComponent(
-  config,
-  components
-);
+const [
+  {
+    TestComponentSimpleCallback,
+    TestComponentCallbackWithReturnCallback,
+    TestComponentCallbackWithValues,
+  },
+  createServer,
+] = createRemoteComponent(config, components);
 
 describe("Callback", () => {
   let sendCounter = 0;
@@ -114,13 +118,10 @@ describe("Callback", () => {
   test("No parameters", () => {
     let called = false;
     const rendered = render(
-      <RemoteComponent
-        name="TestComponentSimpleCallback"
+      <TestComponentSimpleCallback
         webSocket={socket}
-        props={{
-          runsOnClient: () => {
-            called = true;
-          },
+        runsOnClient={() => {
+          called = true;
         }}
       />
     );
@@ -135,13 +136,10 @@ describe("Callback", () => {
   test("With two parameters", () => {
     let result: number[] = [];
     const rendered = render(
-      <RemoteComponent
-        name="TestComponentCallbackWithValues"
+      <TestComponentCallbackWithValues
         webSocket={socket}
-        props={{
-          runsOnClient: ({ a, b }: { a: number; b: number }) => {
-            result = [a, b];
-          },
+        runsOnClient={({ a, b }: { a: number; b: number }) => {
+          result = [a, b];
         }}
       />
     );
@@ -156,20 +154,17 @@ describe("Callback", () => {
   test("With a return callback", () => {
     let result: number[] = [];
     const rendered = render(
-      <RemoteComponent
-        name="TestComponentCallbackWithReturnCallback"
+      <TestComponentCallbackWithReturnCallback
         webSocket={socket}
-        props={{
-          runsOnClient: ({
-            a,
-            runsOnServer,
-          }: {
-            a: number;
-            runsOnServer: (_: { b: number }) => void;
-          }) => {
-            result = [a];
-            runsOnServer({ b: 100 });
-          },
+        runsOnClient={({
+          a,
+          runsOnServer,
+        }: {
+          a: number;
+          runsOnServer: (_: { b: number }) => void;
+        }) => {
+          result = [a];
+          runsOnServer({ b: 100 });
         }}
       />
     );

--- a/packages/integration_tests/src/LocalCallback.test.tsx
+++ b/packages/integration_tests/src/LocalCallback.test.tsx
@@ -22,10 +22,13 @@ const config = {
     onPress: localCallback(InputProp.void, InputProp.void),
   },
   TestComponentCallbackWithValues: {
-    onPress: localCallback(InputProp.boolean, InputProp.object({
-      a: InputProp.number,
-      b: InputProp.number,
-    })),
+    onPress: localCallback(
+      InputProp.boolean,
+      InputProp.object({
+        a: InputProp.number,
+        b: InputProp.number,
+      })
+    ),
   },
 };
 
@@ -47,10 +50,10 @@ const components = {
   },
 };
 
-const [RemoteComponent, createServer] = createRemoteComponent(
-  config,
-  components
-);
+const [
+  { TestComponentSimpleCallback, TestComponentCallbackWithValues },
+  createServer,
+] = createRemoteComponent(config, components);
 
 describe("Callback", () => {
   let sendCounter = 0;
@@ -73,13 +76,10 @@ describe("Callback", () => {
   test("No parameters", () => {
     let called = false;
     const rendered = render(
-      <RemoteComponent
-        name="TestComponentSimpleCallback"
+      <TestComponentSimpleCallback
         webSocket={socket}
-        props={{
-          onPress: () => {
-            called = true;
-          },
+        onPress={() => {
+          called = true;
         }}
       />
     );
@@ -95,14 +95,11 @@ describe("Callback", () => {
     let result: number[] = [];
     let boolResult: boolean = false;
     const rendered = render(
-      <RemoteComponent
-        name="TestComponentCallbackWithValues"
+      <TestComponentCallbackWithValues
         webSocket={socket}
-        props={{
-          onPress: (bool: boolean, args: { a: number; b: number }) => {
-            boolResult = bool;
-            result = [args.a, args.b];
-          },
+        onPress={(bool: boolean, args: { a: number; b: number }) => {
+          boolResult = bool;
+          result = [args.a, args.b];
         }}
       />
     );

--- a/packages/integration_tests/src/Props.test.tsx
+++ b/packages/integration_tests/src/Props.test.tsx
@@ -30,39 +30,18 @@ const components = {
   ),
 };
 
-const RemoteComponent = createRemoteComponentWithDefaultSocket(
-  config,
-  components
-);
+const { Test } = createRemoteComponentWithDefaultSocket(config, components);
 
 describe("Props", () => {
   it("handles optional props", () => {
     expect(
       (getChildren(
-        render(
-          <RemoteComponent
-            name="Test"
-            props={{
-              text: "A",
-              number: 10,
-              textOptional: undefined,
-            }}
-          />
-        )
+        render(<Test text="A" number={10} textOptional={undefined} />)
       )[0] as ReactTestInstance).children[0]
     ).toEqual("A");
     expect(
       (getChildren(
-        render(
-          <RemoteComponent
-            name="Test"
-            props={{
-              text: "A",
-              number: 20,
-              textOptional: "B",
-            }}
-          />
-        )
+        render(<Test text="A" number={20} textOptional={"B"} />)
       )[0] as ReactTestInstance).children[0]
     ).toEqual("AB");
   });
@@ -70,14 +49,8 @@ describe("Props", () => {
     console.error = jest.fn();
     expect(() =>
       render(
-        <RemoteComponent
-          name="Test"
-          // @ts-ignore
-          props={{
-            number: 0,
-            textOptional: undefined,
-          }}
-        />
+        // @ts-ignore
+        <Test number={0} textOptional={undefined} />
       )
     ).toThrow("Required prop 'text' has not been passed to <Test />");
   });

--- a/packages/integration_tests/src/Updates.test.tsx
+++ b/packages/integration_tests/src/Updates.test.tsx
@@ -1,12 +1,12 @@
 jest.mock("react-native", () => ({
-  FlatList: "FlatList",
-  TouchableOpacity: "TouchableOpacity",
+  Text: "Text",
 }));
 jest.mock("react-native-reanimated", () => ({}));
 
 import * as React from "react";
 import { act } from "react-test-renderer";
 import { InputProp } from "nars-common";
+import { Text } from "nars";
 import {
   createRemoteComponent,
   render,
@@ -21,12 +21,12 @@ const config = {
 };
 
 const components = {
-  TestComponent: (props: { aProp: number}) => {
-    return String(props.aProp);
+  TestComponent: (props: { aProp: number }) => {
+    return <Text>{String(props.aProp)}</Text>;
   },
 };
 
-const [RemoteComponent, createServer] = createRemoteComponent(
+const [{ TestComponent }, createServer] = createRemoteComponent(
   config,
   components
 );
@@ -46,30 +46,14 @@ describe("Updates", () => {
         }
       );
       createServer(socket);
-      const rendered = render(
-        <RemoteComponent
-          name="TestComponent"
-          props={{
-            aProp: 1,
-          }}
-          webSocket={socket}
-        />
-      );
+      const rendered = render(<TestComponent aProp={1} webSocket={socket} />);
 
       // Initial render
       expect(sendCounter).toEqual(1);
       expect(counter).toEqual(1);
 
       act(() => {
-        rendered.update(
-          <RemoteComponent
-            name="TestComponent"
-            props={{
-              aProp: 0,
-            }}
-            webSocket={socket}
-          />
-        );
+        rendered.update(<TestComponent aProp={0} webSocket={socket} />);
       });
 
       // Prop change
@@ -77,15 +61,7 @@ describe("Updates", () => {
       expect(counter).toEqual(2);
 
       act(() => {
-        rendered.update(
-          <RemoteComponent
-            name="TestComponent"
-            props={{
-              aProp: 0,
-            }}
-            webSocket={socket}
-          />
-        );
+        rendered.update(<TestComponent aProp={0} webSocket={socket} />);
       });
 
       // Props not changed
@@ -104,15 +80,7 @@ describe("Updates", () => {
       createServer(socket);
 
       act(() => {
-        rendered.update(
-          <RemoteComponent
-            name="TestComponent"
-            props={{
-              aProp: 0,
-            }}
-            webSocket={socket}
-          />
-        );
+        rendered.update(<TestComponent aProp={0} webSocket={socket} />);
       });
       // With a new socket it sends an unmount and render messages
       expect(sendCounter).toEqual(4);

--- a/packages/integration_tests/src/Wait.test.tsx
+++ b/packages/integration_tests/src/Wait.test.tsx
@@ -88,6 +88,7 @@ const [RemoteComponent, createServer] = createRemoteComponent(
 );
 
 const runTest = (name: keyof typeof components) => {
+  const TEST = RemoteComponent[name];
   let sendCounter = 0;
   let counter = 0;
   let socket = testSocketWithMessageSpy(
@@ -100,30 +101,14 @@ const runTest = (name: keyof typeof components) => {
     }
   );
   createServer(socket);
-  const rendered = render(
-    <RemoteComponent
-      name={name}
-      props={{
-        waiting: true,
-      }}
-      webSocket={socket}
-    />
-  );
+  const rendered = render(<TEST waiting={true} webSocket={socket} />);
 
   // Initial render
   expect(sendCounter).toEqual(1);
   expect(counter).toEqual(0);
 
   act(() => {
-    rendered.update(
-      <RemoteComponent
-        name={name}
-        props={{
-          waiting: false,
-        }}
-        webSocket={socket}
-      />
-    );
+    rendered.update(<TEST waiting={false} webSocket={socket} />);
   });
 
   // Prop change
@@ -131,15 +116,7 @@ const runTest = (name: keyof typeof components) => {
   expect(counter).toEqual(1);
 
   act(() => {
-    rendered.update(
-      <RemoteComponent
-        name={name}
-        props={{
-          waiting: true,
-        }}
-        webSocket={socket}
-      />
-    );
+    rendered.update(<TEST waiting={true} webSocket={socket} />);
   });
 
   // Local re-render when local props are updated
@@ -147,15 +124,7 @@ const runTest = (name: keyof typeof components) => {
   expect(counter).toEqual(1);
 
   act(() => {
-    rendered.update(
-      <RemoteComponent
-        name={name}
-        props={{
-          waiting: false,
-        }}
-        webSocket={socket}
-      />
-    );
+    rendered.update(<TEST waiting={false} webSocket={socket} />);
   });
   // With a new socket it sends an unmount and render messages
   expect(sendCounter).toEqual(4);

--- a/packages/nars-client/package.json
+++ b/packages/nars-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nars-client",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "description": "React Native components for Nars",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/nars-client/src/Error.ts
+++ b/packages/nars-client/src/Error.ts
@@ -1,6 +1,5 @@
 export enum UserErrorT {
   BadIncomingRpcCallId,
-  UnknownComponent,
   BadRemoteComponentPropType,
   RequiredPropMissing,
   LocalPropMissing,
@@ -20,13 +19,6 @@ export const badIncomingRpcCallId = (id: number) => {
   return new UserError(
     UserErrorT.BadIncomingRpcCallId,
     `Callback with id '${id}' was not found`
-  );
-};
-
-export const unknownComponent = (component: any) => {
-  return new UserError(
-    UserErrorT.UnknownComponent,
-    `Unknown component <${component} />`
   );
 };
 


### PR DESCRIPTION
This changes the client API from:

```ts
const RemoteComponent = Nars.createRemoteComponentWithUrl(
  "ws://localhost:9000",
  config
);

/* ... */

<RemoteComponent
  name="Feed"
  props={{ backgroundColor: "yellow" }}
/>
```

To:

```ts
const { Feed } = Nars.createRemoteComponentWithUrl(
  "ws://localhost:9000",
  config
);

/* ... */

<Feed backgroundColor={"yellow"} />
```